### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@ Contact : http://www.ozwillo.com/ ozwillo-talk@googlegroups.com
       
       <guava.version>14.0.1</guava.version><!-- for ImmutableMap/List(.Builder),
       also used by MITRE OpenIdConnect & Swagger (in 13.0.1, 11.0.2) -->
-		<commons-collections.version>3.2.1</commons-collections.version><!-- for 
+		<commons-collections.version>3.2.2</commons-collections.version><!-- for 
 			ListUtils -->
 		<commons-lang.version>2.6</commons-lang.version><!-- for ExceptionUtils -->
 		<commons-io.version>2.4</commons-io.version><!-- for IOUtils TODO used ?? -->


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/